### PR TITLE
Publish camera view images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ pkg_check_modules(OGRE OGRE)
 find_package(OpenGL REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
+ cv_bridge
+ image_transport
  rviz
  pluginlib
  std_msgs

--- a/include/rviz_animated_view_controller/rviz_animated_view_controller.h
+++ b/include/rviz_animated_view_controller/rviz_animated_view_controller.h
@@ -330,6 +330,8 @@ protected:    //members
   rviz::RosTopicProperty* camera_placement_topic_property_;
   rviz::RosTopicProperty* camera_trajectory_topic_property_;
 
+  rviz::BoolProperty* publish_view_images_property_;      ///< If True, the camera view is published as images.
+
   rviz::TfFrameProperty* attached_frame_property_;
   Ogre::SceneNode* attached_scene_node_;
 

--- a/include/rviz_animated_view_controller/rviz_animated_view_controller.h
+++ b/include/rviz_animated_view_controller/rviz_animated_view_controller.h
@@ -34,7 +34,13 @@
 
 #include <boost/circular_buffer.hpp>
 
+#include <cv_bridge/cv_bridge.h>
+
+#include <image_transport/image_transport.h>
+
 #include "rviz/view_controller.h"
+#include "rviz/view_manager.h"
+#include "rviz/render_panel.h"
 
 #include <ros/subscriber.h>
 #include <ros/ros.h>
@@ -45,6 +51,7 @@
 #include <view_controller_msgs/CameraPlacement.h>
 #include <view_controller_msgs/CameraTrajectory.h>
 
+#include <OGRE/OgreRenderWindow.h>
 #include <OGRE/OgreVector3.h>
 #include <OGRE/OgreQuaternion.h>
 
@@ -226,6 +233,15 @@ protected:  //methods
   float computeRelativeProgressInSpace(double relative_progress_in_time,
                                        uint8_t interpolation_speed);
 
+  /** @brief Publish the rendered image that is visible to the user in rviz. */
+  void publishViewImage();
+
+  /** @brief Get the current image rviz is showing as an Ogre::PixelBox. */
+  void getViewImage(std::shared_ptr<Ogre::PixelBox>& pixel_box);
+
+  void convertImage(std::shared_ptr<Ogre::PixelBox> input_image,
+                    sensor_msgs::ImagePtr output_image);
+  
   /** @brief Updates the transition_start_time_ and resets the rendered_frames_counter_ for next movement. */
   void prepareNextMovement(const ros::Duration& previous_transition_duration);
   
@@ -334,6 +350,7 @@ protected:    //members
   ros::Subscriber trajectory_subscriber_;
 
   ros::Publisher finished_animation_publisher_;
+  image_transport::Publisher camera_view_image_publisher_;
 
   bool render_frame_by_frame_;
   int target_fps_;

--- a/package.xml
+++ b/package.xml
@@ -14,11 +14,15 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>image_transport</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>view_controller_msgs</build_depend>
   <build_depend>rviz</build_depend>
   <build_depend>pluginlib</build_depend>
 
+  <run_depend>cv_bridge</run_depend>
+  <run_depend>image_transport</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>view_controller_msgs</run_depend>
   <run_depend>rviz</run_depend>

--- a/src/rviz_animated_view_controller.cpp
+++ b/src/rviz_animated_view_controller.cpp
@@ -142,6 +142,10 @@ AnimatedViewController::AnimatedViewController()
                                                            "Topic for CameraTrajectory messages", this,
                                                            SLOT(updateTopics()));
 
+  publish_view_images_property_ = new BoolProperty("Publish View Images During Animation", false, 
+                                                   "If enabled, publishes images of what the user sees in the visualization window during an animation.", 
+                                                   this);
+
   initializePublishers();
 }
 
@@ -632,6 +636,7 @@ void AnimatedViewController::cameraTrajectoryCallback(const view_controller_msgs
   {
     render_frame_by_frame_ = true;
     target_fps_ = static_cast<int>(ct.frames_per_second);
+    publish_view_images_property_->setBool(true);
   }
 
   for(auto& cam_movement : ct.trajectory)
@@ -755,7 +760,7 @@ void AnimatedViewController::update(float dt, float ros_dt)
     camera_->setFixedYawAxis(true, reference_orientation_ * up_vector_property_->getVector());
     camera_->setDirection(reference_orientation_ * (focus_point_property_->getVector() - eye_point_property_->getVector()));
 
-    if(render_frame_by_frame_)
+    if(publish_view_images_property_->getBool())
       publishViewImage();
 
     if(finished_current_movement)

--- a/src/rviz_animated_view_controller.cpp
+++ b/src/rviz_animated_view_controller.cpp
@@ -165,6 +165,9 @@ void AnimatedViewController::updateTopics()
 void AnimatedViewController::initializePublishers()
 {
   finished_animation_publisher_ = nh_.advertise<std_msgs::Bool>("/rviz/finished_animation", 1);
+
+  image_transport::ImageTransport it(nh_);
+  camera_view_image_publisher_ = it.advertise("/rviz/view_image", 1);
 }
 
 void AnimatedViewController::onInitialize()
@@ -752,6 +755,9 @@ void AnimatedViewController::update(float dt, float ros_dt)
     camera_->setFixedYawAxis(true, reference_orientation_ * up_vector_property_->getVector());
     camera_->setDirection(reference_orientation_ * (focus_point_property_->getVector() - eye_point_property_->getVector()));
 
+    if(render_frame_by_frame_)
+      publishViewImage();
+
     if(finished_current_movement)
     {
       // delete current start element in buffer
@@ -797,6 +803,56 @@ float AnimatedViewController::computeRelativeProgressInSpace(double relative_pro
     default:
       return 0.5f * (1.f - static_cast<float>(cos(relative_progress_in_time * M_PI)));
   }
+}
+
+void AnimatedViewController::publishViewImage()
+{
+  if(camera_view_image_publisher_.getNumSubscribers() > 0)
+  {
+    std::shared_ptr<Ogre::PixelBox> pixel_box = std::make_shared<Ogre::PixelBox>();
+    getViewImage(pixel_box);
+
+    sensor_msgs::ImagePtr image_msg = sensor_msgs::ImagePtr(new sensor_msgs::Image());
+    convertImage(pixel_box, image_msg);
+
+    camera_view_image_publisher_.publish(image_msg);
+
+    delete[] (unsigned char*)pixel_box->data;
+  }
+}
+
+void AnimatedViewController::getViewImage(std::shared_ptr<Ogre::PixelBox>& pixel_box)
+{
+  const unsigned int image_height = context_->getViewManager()->getRenderPanel()->getRenderWindow()->getHeight();
+  const unsigned int image_width = context_->getViewManager()->getRenderPanel()->getRenderWindow()->getWidth();
+
+  // create a PixelBox to store the rendered view image
+  const Ogre::PixelFormat pixel_format = Ogre::PF_BYTE_BGR;
+  const auto bytes_per_pixel = Ogre::PixelUtil::getNumElemBytes(pixel_format);
+  auto image_data = new unsigned char[image_width * image_height * bytes_per_pixel];
+  Ogre::Box image_extents(0, 0, image_width, image_height);
+  pixel_box = std::make_shared<Ogre::PixelBox>(image_extents, pixel_format, image_data);
+  context_->getViewManager()->getRenderPanel()->getRenderWindow()->copyContentsToMemory(*pixel_box,
+                                                                                        Ogre::RenderTarget::FB_AUTO);
+}
+
+void AnimatedViewController::convertImage(std::shared_ptr<Ogre::PixelBox> input_image,
+                                          sensor_msgs::ImagePtr output_image)
+{
+  const auto bytes_per_pixel = Ogre::PixelUtil::getNumElemBytes(input_image->format);
+  const auto image_height = input_image->getHeight();
+  const auto image_width = input_image->getWidth();
+
+  output_image->header.frame_id = attached_frame_property_->getStdString();
+  output_image->header.stamp = ros::Time::now();
+  output_image->height = image_height;
+  output_image->width = image_width;
+  output_image->encoding = sensor_msgs::image_encodings::BGR8;
+  output_image->is_bigendian = false;
+  output_image->step = static_cast<unsigned int>(image_width * bytes_per_pixel);
+  size_t size = image_width * image_height * bytes_per_pixel;
+  output_image->data.resize(size);
+  memcpy((char*)(&output_image->data[0]), input_image->data, size);
 }
 
 void AnimatedViewController::prepareNextMovement(const ros::Duration& previous_transition_duration)


### PR DESCRIPTION
Addresses the [issue](https://github.com/ros-visualization/rviz_animated_view_controller/issues/11) of the [base repository](https://github.com/ros-visualization/rviz_animated_view_controller). 

This pull request adds a publisher for the current view the user sees in the rviz visualization window.
The view is published as an image during a requested animation. 
Can be toggled using a bool property in the view controller panel. 

Depends on another [pull request](https://github.com/ros-visualization/rviz_animated_view_controller/pull/14) introducing camera trajectories, because the publisher is automatically activated when a requested camera trajectory should be rendered frame by frame.
Currently this PR cannot be based upon the other PR because it's not merged yet. 
This PR will be redirected when the other is merged. 